### PR TITLE
Added HTTP API timeout option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
-dist
-node_modules
+/.idea/
+/dist/
+/node_modules/
+/package-lock.json

--- a/src/client/TonClient.ts
+++ b/src/client/TonClient.ts
@@ -73,7 +73,7 @@ export class TonClient {
     constructor(parameters: TonClientParameters) {
         this.parameters = {
             endpoint: parameters.endpoint,
-            cache: parameters.cache ? parameters.cache : new InMemoryCache(),
+            cache: parameters.cache ? parameters.cache : new InMemoryCache()
         };
         this.#api = new HttpApi(this.parameters.endpoint, this.parameters.cache, {
             timeout: parameters.timeout,

--- a/src/client/TonClient.ts
+++ b/src/client/TonClient.ts
@@ -18,6 +18,12 @@ import { InMemoryCache, TonCache } from './TonCache';
 export type TonClientParameters = {
     endpoint: string;
     cache?: Maybe<TonCache>;
+
+    /**
+     * HTTP request timeout in milliseconds.
+     */
+    timeout?: number;
+
 }
 
 export type TonClientResolvedParameters = {
@@ -67,9 +73,11 @@ export class TonClient {
     constructor(parameters: TonClientParameters) {
         this.parameters = {
             endpoint: parameters.endpoint,
-            cache: parameters.cache ? parameters.cache : new InMemoryCache()
+            cache: parameters.cache ? parameters.cache : new InMemoryCache(),
         };
-        this.#api = new HttpApi(this.parameters.endpoint, this.parameters.cache);
+        this.#api = new HttpApi(this.parameters.endpoint, this.parameters.cache, {
+            timeout: parameters.timeout,
+        });
     }
 
     /**
@@ -155,9 +163,9 @@ export class TonClient {
 
     /**
      * Fetch transactions inf shards
-     * @param workchain 
-     * @param seqno 
-     * @param shard 
+     * @param workchain
+     * @param seqno
+     * @param shard
      */
     async getShardTransactions(workchain: number, seqno: number, shard: string) {
         let tx = await this.#api.getBlockTransactions(workchain, seqno, shard);

--- a/src/client/api/HttpApi.ts
+++ b/src/client/api/HttpApi.ts
@@ -286,7 +286,7 @@ export class HttpApi {
                 method: method,
                 params: body
             }),
-        }), this.parameters.timeout!);
+        }), this.parameters.timeout);
         if (!res.ok) {
             throw Error('Received error: ' + await res.text());
         }


### PR DESCRIPTION
This PR introduces a `timeout` property that can be configured on `TonClient` instance that is getting propagated to the HTTP API client.

Signed-off-by: Slava Fomin II <slava@fomin.io>