### PR TITLE
fix: boc cells index, offset changed to end instead of start

### DIFF
--- a/src/boc/boc.ts
+++ b/src/boc/boc.ts
@@ -405,8 +405,8 @@ export function serializeToBoc(cell: Cell, has_idx = true, hash_crc32 = true, ha
         let full_size = 0;
         let sizeIndex: number[] = [];
         for (let cell_info of allCells) {
-            sizeIndex.push(full_size);
             full_size = full_size + (serializeForBoc(cell_info.cell, cell_info.refs, s_bytes)).length;
+            sizeIndex.push(full_size);
         }
         const offset_bits = full_size.toString(2).length; // Minimal number of bits to offset/len (unused?)
         const offset_bytes = Math.max(Math.ceil(offset_bits / 8), 1);


### PR DESCRIPTION
Current behavior seems incorrect, index should store end of cell, not start.

This is how its implemented in ton node:
https://github.com/ton-blockchain/ton/blob/24dc184a2ea67f9c47042b4104bbb4d82289fac1/crypto/vm/boc.cpp#L545

Havent found exact place where index is used on deserialization, is its implemented without index usage currently?