### PR TITLE
Adding support for wallet V4

### DIFF
--- a/src/client/Wallet.ts
+++ b/src/client/Wallet.ts
@@ -8,6 +8,7 @@ import { WalletV2R1Source } from "../contracts/sources/WalletV2R1Source";
 import { WalletV2R2Source } from "../contracts/sources/WalletV2R2Source";
 import { WalletV3R1Source } from "../contracts/sources/WalletV3R1Source";
 import { WalletV3R2Source } from "../contracts/sources/WalletV3R2Source";
+import { WalletV4Source } from "../contracts/sources/WalletV4Source";
 import { WalletContract } from "../contracts/WalletContract";
 import { CommonMessageInfo } from "../messages/CommonMessageInfo";
 import { InternalMessage } from "../messages/InternalMessage";
@@ -21,14 +22,16 @@ export type WalletContractType =
     | 'org.ton.wallets.v2'
     | 'org.ton.wallets.v2.r2'
     | 'org.ton.wallets.v3'
-    | 'org.ton.wallets.v3.r2';
+    | 'org.ton.wallets.v3.r2'
+    | 'org.ton.wallets.v4';
 
 // Wallet Contract Priority
-const allTypes: WalletContractType[] = [
+export const allTypes: WalletContractType[] = [
     'org.ton.wallets.simple.r2',
     'org.ton.wallets.simple.r3',
     'org.ton.wallets.v2',
     'org.ton.wallets.v2.r2',
+    'org.ton.wallets.v4',
     'org.ton.wallets.v3.r2', // We prefer r1 instead of r2
     'org.ton.wallets.v3'
 ];
@@ -40,7 +43,8 @@ export function validateWalletType(src: string): WalletContractType | null {
         || src === 'org.ton.wallets.v2'
         || src === 'org.ton.wallets.v2.r2'
         || src === 'org.ton.wallets.v3'
-        || src === 'org.ton.wallets.v3.r2') {
+        || src === 'org.ton.wallets.v3.r2'
+        || src === 'org.ton.wallets.v4') {
         return src;
     }
 
@@ -62,6 +66,8 @@ function createContract(client: TonClient, type: WalletContractType, publicKey: 
         return WalletContract.create(client, WalletV3R1Source.create({ publicKey, workchain }));
     } else if (type === 'org.ton.wallets.v3.r2') {
         return WalletContract.create(client, WalletV3R2Source.create({ publicKey, workchain }));
+    } else if (type === 'org.ton.wallets.v4') {
+        return WalletContract.create(client, WalletV4Source.create({ publicKey, workchain }));
     } else {
         throw Error('Unknown wallet type: ' + type);
     }

--- a/src/contracts/WalletContract.spec.ts
+++ b/src/contracts/WalletContract.spec.ts
@@ -18,6 +18,7 @@ import { WalletV2R1Source } from "./sources/WalletV2R1Source";
 import { WalletV2R2Source } from "./sources/WalletV2R2Source";
 import { WalletV3R1Source } from "./sources/WalletV3R1Source";
 import { WalletV3R2Source } from "./sources/WalletV3R2Source";
+import { WalletV4Source } from "./sources/WalletV4Source";
 import { WalletContract } from "./WalletContract";
 
 async function testSource(secretKey: Buffer, source: WalletSource) {
@@ -100,5 +101,12 @@ describe('WalletContract', () => {
         let key = await mnemonicToWalletKey(mnemonic);
         await testSource(key.secretKey, WalletV3R2Source.create({ publicKey: key.publicKey, workchain: 0 }));
         await testSource(key.secretKey, WalletV3R2Source.create({ publicKey: key.publicKey, workchain: -1 }));
+    }, 120000);
+
+    it('should work for v4 contract', async () => {
+        let mnemonic = await mnemonicNew(24);
+        let key = await mnemonicToWalletKey(mnemonic);
+        await testSource(key.secretKey, WalletV4Source.create({ publicKey: key.publicKey, workchain: 0 }));
+        await testSource(key.secretKey, WalletV4Source.create({ publicKey: key.publicKey, workchain: -1 }));
     }, 120000);
 });

--- a/src/contracts/WalletContract.ts
+++ b/src/contracts/WalletContract.ts
@@ -1,7 +1,7 @@
 import { Address, TonClient } from "..";
 import { InternalMessage } from "../messages/InternalMessage";
 import { Contract } from "./Contract";
-import { createWalletTransferV1, createWalletTransferV2, createWalletTransferV3 } from "./messages/createWalletTransfer";
+import { createWalletTransferV1, createWalletTransferV2, createWalletTransferV3, createWalletTransferV4 } from "./messages/createWalletTransfer";
 import { WalletSource } from "./sources/WalletSource";
 import { Maybe } from "../types";
 import { contractAddress } from "./contractAddress";
@@ -40,6 +40,8 @@ export class WalletContract implements Contract {
                 return createWalletTransferV2({ seqno: args.seqno, sendMode: args.sendMode, secretKey: args.secretKey, order: args.order, timeout: args.timeout });
             case 'v3':
                 return createWalletTransferV3({ seqno: args.seqno, sendMode: args.sendMode, secretKey: args.secretKey, order: args.order, walletId: this.source.walletId, timeout: args.timeout });
+            case 'v4':
+                return createWalletTransferV4({ seqno: args.seqno, sendMode: args.sendMode, secretKey: args.secretKey, order: args.order, walletId: this.source.walletId, timeout: args.timeout });
             default:
                 throw Error('Unknown contract type: ' + (this.source as any).type);
         }

--- a/src/contracts/messages/WalletV4SigningMessage.ts
+++ b/src/contracts/messages/WalletV4SigningMessage.ts
@@ -1,0 +1,53 @@
+import { Cell } from "../../boc/Cell";
+import { Maybe } from "../../types";
+import { Message } from "../../messages/Message";
+
+export class WalletV4SigningMessage implements Message {
+
+    readonly timeout: number;
+    readonly seqno: number;
+    readonly walletId: number;
+    readonly order: Message | null;
+    readonly sendMode: number;
+
+    constructor(args: { timeout?: Maybe<number>, seqno: Maybe<number>, walletId?: number, sendMode: number, order: Message | null }) {
+        this.order = args.order;
+        this.sendMode = args.sendMode;
+        if (args.timeout !== undefined && args.timeout !== null) {
+            this.timeout = args.timeout;
+        } else {
+            this.timeout = Math.floor(Date.now() / 1e3) + 60; // Default timeout: 60 seconds
+        }
+        if (args.seqno !== undefined && args.seqno !== null) {
+            this.seqno = args.seqno;
+        } else {
+            this.seqno = 0;
+        }
+        if (args.walletId !== null && args.walletId !== undefined) {
+            this.walletId = args.walletId;
+        } else {
+            this.walletId = 698983191;
+        }
+    }
+
+    writeTo(cell: Cell) {
+        cell.bits.writeUint(this.walletId, 32);
+        if (this.seqno === 0) {
+            for (let i = 0; i < 32; i++) {
+                cell.bits.writeBit(1);
+            }
+        } else {
+            cell.bits.writeUint(this.timeout, 32);
+        }
+        cell.bits.writeUint(this.seqno, 32);
+        cell.bits.writeUint8(0); // Simple order
+
+        // Write order
+        if (this.order) {
+            cell.bits.writeUint8(this.sendMode);
+            let orderCell = new Cell();
+            this.order.writeTo(orderCell);
+            cell.refs.push(orderCell);
+        }
+    }
+}

--- a/src/contracts/messages/createWalletTransfer.ts
+++ b/src/contracts/messages/createWalletTransfer.ts
@@ -4,6 +4,7 @@ import { Maybe } from "../../types";
 import { WalletV1SigningMessage } from "./WalletV1SigningMessage";
 import { WalletV2SigningMessage } from "./WalletV2SigningMessage";
 import { WalletV3SigningMessage } from "./WalletV3SigningMessage";
+import { WalletV4SigningMessage } from "./WalletV4SigningMessage";
 
 export function createWalletTransferV1(args: { seqno: number, sendMode: number, order: InternalMessage, secretKey: Buffer }) {
 
@@ -69,6 +70,41 @@ export function createWalletTransferV3(args: {
     const cell = new Cell();
     signingMessage.writeTo(cell);
     let signature = sign(cell.hash(), args.secretKey);
+
+    // Body
+    const body = new Cell();
+    body.bits.writeBuffer(signature);
+    signingMessage.writeTo(body);
+
+    return body;
+}
+
+export function createWalletTransferV4(args: {
+    seqno: number,
+    sendMode: number,
+    walletId: number,
+    order: InternalMessage | null,
+    secretKey?: Maybe<Buffer>,
+    timeout?: Maybe<number>
+}) {
+
+    let signingMessage = new WalletV4SigningMessage({
+        timeout: args.timeout,
+        walletId: args.walletId,
+        seqno: args.seqno,
+        sendMode: args.sendMode,
+        order: args.order
+    });
+
+    // Sign message
+    const cell = new Cell();
+    signingMessage.writeTo(cell);
+    let signature: Buffer;
+    if (args.secretKey) {
+        signature = sign(cell.hash(), args.secretKey);
+    } else {
+        signature = Buffer.alloc(64);
+    }
 
     // Body
     const body = new Cell();

--- a/src/contracts/sources/WalletSource.ts
+++ b/src/contracts/sources/WalletSource.ts
@@ -11,5 +11,9 @@ export type WalletSource =
         {
             readonly walletVersion: 'v3';
             readonly walletId: number;
+        } |
+        {
+            readonly walletVersion: 'v4';
+            readonly walletId: number;
         }
     )

--- a/src/contracts/sources/WalletV4Source.ts
+++ b/src/contracts/sources/WalletV4Source.ts
@@ -1,0 +1,61 @@
+import { Cell, ConfigStore, ContractSource } from "../..";
+import { Maybe } from "../../types";
+
+export class WalletV4Source implements ContractSource {
+
+    static readonly SOURCE = Buffer.from(
+        'te6ccgECFAEAAtQAART/APSkE/S88sgLAQIBIAIDAgFIBAUE+PKDCNcYINMf0x/THwL4I7vyZO1E0NMf0x/T//QE0VFDuvKhUVG68qIF+QFUEGT5EPKj+AAkpMjLH1JAyx9SMMv/UhD0AMntVPgPAdMHIcAAn2xRkyDXSpbTB9QC+wDoMOAhwAHjACHAAuMAAcADkTDjDQOkyMsfEssfy/8QERITAubQAdDTAyFxsJJfBOAi10nBIJJfBOAC0x8hghBwbHVnvSKCEGRzdHK9sJJfBeAD+kAwIPpEAcjKB8v/ydDtRNCBAUDXIfQEMFyBAQj0Cm+hMbOSXwfgBdM/yCWCEHBsdWe6kjgw4w0DghBkc3RyupJfBuMNBgcCASAICQB4AfoA9AQw+CdvIjBQCqEhvvLgUIIQcGx1Z4MesXCAGFAEywUmzxZY+gIZ9ADLaRfLH1Jgyz8gyYBA+wAGAIpQBIEBCPRZMO1E0IEBQNcgyAHPFvQAye1UAXKwjiOCEGRzdHKDHrFwgBhQBcsFUAPPFiP6AhPLassfyz/JgED7AJJfA+ICASAKCwBZvSQrb2omhAgKBrkPoCGEcNQICEekk30pkQzmkD6f+YN4EoAbeBAUiYcVnzGEAgFYDA0AEbjJftRNDXCx+AA9sp37UTQgQFA1yH0BDACyMoHy//J0AGBAQj0Cm+hMYAIBIA4PABmtznaiaEAga5Drhf/AABmvHfaiaEAQa5DrhY/AAG7SB/oA1NQi+QAFyMoHFcv/ydB3dIAYyMsFywIizxZQBfoCFMtrEszMyXP7AMhAFIEBCPRR8qcCAHCBAQjXGPoA0z/IVCBHgQEI9FHyp4IQbm90ZXB0gBjIywXLAlAGzxZQBPoCFMtqEssfyz/Jc/sAAgBsgQEI1xj6ANM/MFIkgQEI9Fnyp4IQZHN0cnB0gBjIywXLAlAFzxZQA/oCE8tqyx8Syz/Jc/sAAAr0AMntVA==',
+        'base64'
+    );
+
+    static create(opts: { workchain: number, publicKey: Buffer, walletId?: Maybe<number> }) {
+
+        // Build initial code and data
+        const walletId = opts.walletId ? opts.walletId : 698983191;
+        let initialCode = Cell.fromBoc(WalletV4Source.SOURCE)[0];
+        let initialData = new Cell();
+        initialData.bits.writeUint(0, 32);
+        initialData.bits.writeUint(walletId, 32);
+        initialData.bits.writeBuffer(opts.publicKey);
+        initialData.bits.writeBit(0);
+
+        return new WalletV4Source({ initialCode, initialData, workchain: opts.workchain, walletId, publicKey: opts.publicKey });
+    }
+
+    static restore(backup: string) {
+        const store = new ConfigStore(backup);
+        return WalletV4Source.create({
+            workchain: store.getInt('wc'),
+            publicKey: store.getBuffer('pk'),
+            walletId: store.getInt('walletId'),
+        });
+    }
+
+    readonly initialCode: Cell;
+    readonly initialData: Cell;
+    readonly walletId: number;
+    readonly workchain: number;
+    readonly publicKey: Buffer;
+    readonly type = 'org.ton.wallets.v4';
+    readonly walletVersion = 'v4';
+
+    private constructor(args: { initialCode: Cell, initialData: Cell, workchain: number, walletId: number, publicKey: Buffer }) {
+        this.initialCode = args.initialCode;
+        this.initialData = args.initialData;
+        this.workchain = args.workchain;
+        this.walletId = args.walletId;
+        this.publicKey = args.publicKey;
+    }
+
+    describe() {
+        return 'Wallet v4 #' + this.walletId;
+    }
+
+    backup() {
+        const config = new ConfigStore();
+        config.setInt('wc', this.workchain);
+        config.setBuffer('pk', this.publicKey);
+        config.setInt('walletId', this.walletId);
+        return config.save();
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ export { BitStringReader } from './boc/BitStringReader';
 export { Cell } from './boc/Cell';
 export { CellType } from './boc/CellType';
 export { TonClient } from './client/TonClient';
-export { Wallet, validateWalletType, WalletContractType } from './client/Wallet';
+export { Wallet, validateWalletType, WalletContractType, allTypes as AllWalletContractTypes } from './client/Wallet';
 export { Address } from './address/Address';
 export { toNano, fromNano } from './utils/convert';
 export { KeyStore, KeyRecord } from './keystore/KeyStore';


### PR DESCRIPTION
Closes #16 

Code was taken from https://github.com/tonwhales/ton-contracts/blob/master/src/contracts/WalletV4Contract.ts

and just organized in the correct way

It's important to add support because some wallet like TonKeeper deploy by default V4 wallets and ton package cannot work with them